### PR TITLE
Upload Build Artifact in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,11 @@ jobs:
 
       - name: List built files
         run: ls -l weather
+
+      - name: Upload Weather Binary
+        uses: actions/upload-artifact@v4 
+        with:
+          name: weather-${{ github.run_number }} # Unique name for the artifact
+          path: ./weather # Path to the built binary
+          retention-days: 7 # Retain artifact for 7 days
+ 


### PR DESCRIPTION
# Pull Request: Upload Build Artifact in GitHub Actions

## Description
This PR updates the GitHub Actions workflow to **upload the compiled `weather` binary** as a build artifact after a successful build.  

Previously, the workflow only compiled the binary for verification but did not preserve the output. Uploading the artifact enables:

- Easy access to build binaries for manual testing or deployment  
- Integration with deployment workflows or distribution pipelines  
- Archiving of build outputs for traceability  

## Changes
- Added `actions/upload-artifact` step to the workflow  
- Specifies the compiled binary (`./weather`) as the artifact to upload  
- Configured artifact naming using `weather-${{ github.run_number }}`  
- Set retention to 7 days (adjustable as needed)

### How to load Binary on to the Raspberry Pi
-Download the binary from Github
-scp weather gagem@pi.local:/home/gagem/Bins
-chmod +x ~/weather
-./weather

### Example Workflow Snippet
```yaml
- name: Upload Weather Binary
  uses: actions/upload-artifact@v4
  with:
    name: weather-${{ github.run_number }}
    path: ./weather
    retention-days: 7