### PR TITLE
bug/Fix Pi 5 hardware deployment: IPv4 curl, timeouts, systemd service paths

### DIFF
--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -12,7 +12,6 @@ std::string urlEncode(const std::string &value) {
     std::ostringstream escaped;
     escaped.fill('0');
     escaped << std::hex;
-
     for (char c : value) {
         if (isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == '.' || c == '~') {
             escaped << c;
@@ -35,14 +34,14 @@ Weather getWeather(const std::string& apiKey, const std::string& city, std::stri
     CURLcode res;
     std::string readBuffer;
 
-    std::string url = "https://api.weatherapi.pzcom/v1/current.json?key=" + apiKey + "&q=" + urlEncode(city);
-
+    std::string url = "https://api.weatherapi.com/v1/current.json?key=" + apiKey + "&q=" + urlEncode(city);
     std::cout << "[INFO] Requesting weather for: " << city << std::endl;
 
     curl_global_init(CURL_GLOBAL_DEFAULT);
     curl = curl_easy_init();
     if (!curl) {
         std::cerr << "[ERROR] CURL init failed\n";
+        curl_global_cleanup();
         return Weather{"N/A", 0.0f};
     }
 
@@ -50,7 +49,17 @@ Weather getWeather(const std::string& apiKey, const std::string& city, std::stri
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 
+    // Force IPv4. Some networks have broken IPv6 routing that causes
+    // libcurl to fail with "Could not resolve hostname" even when DNS
+    // is fine and the curl CLI succeeds (it falls back to IPv4 quickly).
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+
+    // Reasonable timeouts so a flaky network doesn't hang the main loop.
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
+
     res = curl_easy_perform(curl);
+
     if (res != CURLE_OK) {
         std::cerr << "[ERROR] CURL request failed: " << curl_easy_strerror(res) << "\n";
         curl_easy_cleanup(curl);
@@ -60,7 +69,6 @@ Weather getWeather(const std::string& apiKey, const std::string& city, std::stri
 
     if (rawResponse) {
         *rawResponse = readBuffer;
-        std::cout << "[DEBUG] API Response: " << readBuffer << std::endl;
     }
 
     curl_easy_cleanup(curl);
@@ -84,7 +92,6 @@ Weather getWeather(const std::string& apiKey, const std::string& city, std::stri
         }
 
         return Weather{description, temp};
-
     } catch (const json::exception& e) {
         std::cerr << "[ERROR] JSON parsing error: " << e.what() << "\n";
         return Weather{"N/A", 0.0f};

--- a/systemd/weather-display.service
+++ b/systemd/weather-display.service
@@ -5,14 +5,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/home/gagem/Documents/WeatherDisplay/build/bin/weather_display
-WorkingDirectory=/home/gagem/Documents/WeatherDisplay
+ExecStart=/usr/local/bin/weather_display
+WorkingDirectory=/home/pi/Documents/WeatherDisplay
 Restart=on-failure
 RestartSec=10
-User=gagem
+User=pi
 
 # Pass environment from a file so secrets aren't in the unit.
-EnvironmentFile=-/home/gagem/Documents/WeatherDisplay/.env
+EnvironmentFile=-/home/pi/Documents/WeatherDisplay/.env
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary

Follow-up to the C++ OLED port PR. Fixes issues discovered during real
hardware deployment on a fresh Raspberry Pi 5 install:

- libcurl was failing on networks with broken IPv6 routing
- Weather API calls could stall the main loop indefinitely on flaky networks
- The systemd service file had stale user/path values from a previous deployment

After this PR, the device boots, starts the service automatically,
and runs both displays continuously without intervention.

## What changed

### `src/weather.cpp`
- Force IPv4 in libcurl with `CURLOPT_IPRESOLVE = CURL_IPRESOLVE_V4`.
  Some networks return "Network is unreachable" for IPv6 connections,
  which libcurl reports as "Could not resolve hostname" even though
  IPv4 DNS works fine. The `curl` CLI hides this by quickly falling
  back to IPv4; libcurl with default settings does not.
- Add `CURLOPT_CONNECTTIMEOUT = 5s` and `CURLOPT_TIMEOUT = 10s` so a
  flaky API call cannot stall the main loop and freeze the OLED tick.
- Move `curl_global_cleanup()` so it always runs on early-exit paths.
- Remove the verbose `[DEBUG] API Response:` print of the full JSON
  body (noisy and contains the location echo).

### `systemd/weather-display.service`
- Update `ExecStart` to `/usr/local/bin/weather_display` (where
  `make install-service` actually places the binary) instead of the
  build-tree path.
- Update `User=` from a stale username to `pi` so the service can
  start on a default Pi OS install.
- Update `EnvironmentFile=` path to `/home/pi/...` to match.

## Hardware verification

Tested on a Raspberry Pi 5 with fresh Pi OS Lite (64-bit), the
GeeekPi 16x2 LCD (I2C 0x27), the GeeekPi 0.96" SSD1306 OLED (I2C 0x3C),
and a 16-LED NeoPixel ring (not yet driven by this binary).

Verified end-to-end:

- Build succeeds with GCC 14.2.0 + CMake on Pi OS
- Both I2C devices visible at expected addresses
- Weather fetches successfully against weatherapi.com over IPv4 only
- LCD shows current weather (`Temp: 59F` / `Partly cloudy`)
- OLED ticks current time every second (`HH:MM:SS` auto-fit)
- `make install-service` installs and starts the unit cleanly
- `systemctl status weather-display` reports `active (running)`
- **Reboot test:** device powers up → both displays come alive
  automatically, no SSH or manual steps required

## Refs

`Refs #27` — systemd service file is now production-deployable
on the default Pi user account.

## Follow-ups
- [ ] Generalize the systemd service for arbitrary users (closes #8)
- [ ] Update README to document the `.env` workflow and the
      `make install-service` flow (related to #28)
- [ ] Port `led_celestial_display.py` to C++ via SPI (next PR)