### PR TITLE
docs: add .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# WeatherDisplay environment configuration
+# Copy this file to .env and fill in real values.
+# Never commit .env to git.
+
+WEATHER_API_KEY=your_weatherapi_com_key_here
+WEATHER_LOCATION="Westmont, IL"
+UNITS=F
+UPDATE_INTERVAL=600
+OLED_FORMAT="II:MM AP"
+OLED_SCALE=auto
+GMAIL_USER=your_email@gmail.com
+GMAIL_APP_PASSWORD="xxxx xxxx xxxx xxxx"
+ALERT_RECIPIENT=your_email@gmail.com

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # Never commit .env to git.
 
 WEATHER_API_KEY=your_weatherapi_com_key_here
-WEATHER_LOCATION="Westmont, IL"
+WEATHER_LOCATION="Your City, ST"
 UNITS=F
 UPDATE_INTERVAL=600
 OLED_FORMAT="II:MM AP"

--- a/README.md
+++ b/README.md
@@ -110,17 +110,17 @@ Two layers, in order of precedence:
 
 1. **Environment variables** (highest priority). Copy `.env.example` to `.env`, fill in your local values, then load it from systemd in the project root or set variables manually in the shell:
 
-   | Variable             | Purpose                              |
-   |----------------------|--------------------------------------|
-   | `WEATHER_API_KEY`    | weatherapi.com API key (required)    |
-   | `WEATHER_LOCATION`   | City for weather lookup              |
-   | `UNITS`              | `F` or `C` (default `F`)             |
-   | `UPDATE_INTERVAL`    | Seconds between weather fetches      |
-   | `OLED_FORMAT`        | OLED time format string              |
-   | `OLED_SCALE`         | OLED text scale (`auto` or `1`-`4`)  |
-   | `GMAIL_USER`         | Sender Gmail address for alerts      |
-   | `GMAIL_APP_PASSWORD` | Gmail app password for SMTP alerts   |
-   | `ALERT_RECIPIENT`    | Destination email for alerts         |
+   | Variable             | Purpose                                                                |
+   |----------------------|------------------------------------------------------------------------|
+   | `WEATHER_API_KEY`    | weatherapi.com API key (required)                                      |
+   | `WEATHER_LOCATION`   | City for weather lookup                                                |
+   | `UNITS`              | `F` or `C` (default `F`)                                               |
+   | `UPDATE_INTERVAL`    | Seconds between weather fetches                                        |
+   | `OLED_FORMAT`        | OLED time format string - II=hours, MM=minutes, SS=seconds, AP=am/pm   |
+   | `OLED_SCALE`         | OLED text scale (`auto` or `1`-`4`)                                    |
+   | `GMAIL_USER`         | Sender Gmail address for alerts                                        |
+   | `GMAIL_APP_PASSWORD` | Gmail app password for SMTP alerts                                     |
+   | `ALERT_RECIPIENT`    | Destination email for alerts                                           |
 
 2. **`config.json`** in the project root:
 

--- a/README.md
+++ b/README.md
@@ -108,16 +108,19 @@ open test_output/ring_day_*.ppm
 
 Two layers, in order of precedence:
 
-1. **Environment variables** (highest priority). Loaded by systemd from `.env` in the project root, or set manually in the shell:
+1. **Environment variables** (highest priority). Copy `.env.example` to `.env`, fill in your local values, then load it from systemd in the project root or set variables manually in the shell:
 
-   | Variable           | Purpose                              |
-   |--------------------|--------------------------------------|
-   | `WEATHER_API_KEY`  | weatherapi.com API key (required)    |
-   | `WEATHER_LOCATION` | City for weather lookup              |
-   | `UNITS`            | `F` or `C` (default `F`)             |
-   | `UPDATE_INTERVAL`  | Seconds between weather fetches      |
-   | `OLED_FORMAT`      | OLED time format string              |
-   | `OLED_SCALE`       | OLED text scale (`auto` or `1`-`4`)  |
+   | Variable             | Purpose                              |
+   |----------------------|--------------------------------------|
+   | `WEATHER_API_KEY`    | weatherapi.com API key (required)    |
+   | `WEATHER_LOCATION`   | City for weather lookup              |
+   | `UNITS`              | `F` or `C` (default `F`)             |
+   | `UPDATE_INTERVAL`    | Seconds between weather fetches      |
+   | `OLED_FORMAT`        | OLED time format string              |
+   | `OLED_SCALE`         | OLED text scale (`auto` or `1`-`4`)  |
+   | `GMAIL_USER`         | Sender Gmail address for alerts      |
+   | `GMAIL_APP_PASSWORD` | Gmail app password for SMTP alerts   |
+   | `ALERT_RECIPIENT`    | Destination email for alerts         |
 
 2. **`config.json`** in the project root:
 
@@ -168,10 +171,8 @@ Two layers, in order of precedence:
 
 ```sh
 # Set secrets
-cat > .env <<'EOF'
-WEATHER_API_KEY=your_weatherapi_key
-WEATHER_LOCATION="Westmont, IL"
-EOF
+cp .env.example .env
+# Edit .env and fill in real values.
 chmod 600 .env
 
 # Install


### PR DESCRIPTION
## Problem

A fresh clone requires a local `.env` file, but the repository only documents the variable names in the README. Because `.env` is correctly ignored, contributors have to reconstruct the file manually and can easily miss or mistype values.

## Root Cause

The project has runtime configuration split across weather lookup, OLED display settings, update cadence, and Gmail alerting, but there is no tracked template that shows the complete expected shape of the environment file.

## What Changed

- Added a tracked `.env.example` with placeholder values for weather, OLED, interval, and Gmail alert configuration.
- Updated the README to start setup from `cp .env.example .env`.
- Documented the Gmail alert variables already read by `src/alerter.cpp`.

## Why This Approach

A template keeps secrets out of git while giving new contributors a copy-paste starting point that matches the code. It also keeps `.env` ignored and confirms `.env.example` remains trackable.

## Validation

- `git diff --check`
- `git check-ignore -v .env .env.example`
- `rg "GMAIL_USER|GMAIL_APP_PASSWORD|ALERT_RECIPIENT|cp \.env\.example \.env" README.md .env.example`

## Risk

Low. This is documentation plus a placeholder template. No runtime defaults or secret handling logic changed.

Closes #65
